### PR TITLE
Support multiple api groups per resource

### DIFF
--- a/pkg/cmd/permissions.go
+++ b/pkg/cmd/permissions.go
@@ -109,14 +109,16 @@ func (o *PermissionsOptions) Run() error {
 				// lets get the permissions
 				for _, rule := range clusterRole.Rules {
 					for _, resourceName := range rule.Resources {
-						root.Add(fmt.Sprintf("ServiceAccount/%s (%s)#ClusterRoleBinding/%s#ClusterRole/%s#%s#%s verbs=%s",
-							sa.Name,
-							sa.Namespace,
-							clusterRoleBinding.Name,
-							clusterRole.Name,
-							apiGroup(rule.APIGroups),
-							resourceName,
-							rule.Verbs))
+						for _, apiGroup := range rule.APIGroups {
+							root.Add(fmt.Sprintf("ServiceAccount/%s (%s)#ClusterRoleBinding/%s#ClusterRole/%s#%s#%s verbs=%s",
+								sa.Name,
+								sa.Namespace,
+								clusterRoleBinding.Name,
+								clusterRole.Name,
+								getApiGroup(apiGroup),
+								resourceName,
+								rule.Verbs))
+						}
 					}
 				}
 			}
@@ -144,16 +146,18 @@ func (o *PermissionsOptions) Run() error {
 				// lets get the permissions
 				for _, rule := range role.Rules {
 					for _, resourceName := range rule.Resources {
-						root.Add(fmt.Sprintf("ServiceAccount/%s (%s)#RoleBinding/%s (%s)#Role/%s (%s)#%s#%s verbs=%s",
-							sa.Name,
-							sa.Namespace,
-							roleBinding.Name,
-							roleBinding.Namespace,
-							role.Name,
-							role.Namespace,
-							apiGroup(rule.APIGroups),
-							resourceName,
-							rule.Verbs))
+						for _, apiGroup := range rule.APIGroups {
+							root.Add(fmt.Sprintf("ServiceAccount/%s (%s)#RoleBinding/%s (%s)#Role/%s (%s)#%s#%s verbs=%s",
+								sa.Name,
+								sa.Namespace,
+								roleBinding.Name,
+								roleBinding.Namespace,
+								role.Name,
+								role.Namespace,
+								getApiGroup(apiGroup),
+								resourceName,
+								rule.Verbs))
+						}
 					}
 				}
 			}
@@ -174,15 +178,9 @@ func matches(subjects []v1.Subject, namespace string, name string) bool {
 	return false
 }
 
-func apiGroup(in []string) string {
+func getApiGroup(in string) string {
 	if len(in) == 0 {
-		return "empty"
-	} else if len(in) == 1 {
-		if in[0] == "" {
-			return "<default>"
-		}
-		return in[0]
-	} else {
-		panic("expected length 1")
+		return "core.k8s.io"
 	}
+	return in
 }


### PR DESCRIPTION
When attempting to list permission for the `deployment-controller` service account in the `kube-system` namespace I get the following error:
```sh
$ k permissions "deployment-controller" -n kube-system                                                                                                    ─╯
panic: expected length 1

goroutine 1 [running]:
github.com/garethjevans/permissions/pkg/cmd.apiGroup(...)
        /Users/caicooper/workspace/kubectl-permissions/pkg/cmd/permissions.go:186
github.com/garethjevans/permissions/pkg/cmd.(*PermissionsOptions).Run(0xc000112780)
        /Users/caicooper/workspace/kubectl-permissions/pkg/cmd/permissions.go:117 +0x11e5
github.com/garethjevans/permissions/pkg/cmd.NewCmdPermissions.func1(0xc000004780?, {0xc000121f80?, 0x1?, 0x3?})
        /Users/caicooper/workspace/kubectl-permissions/pkg/cmd/permissions.go:49 +0x1d
github.com/spf13/cobra.(*Command).execute(0xc000004780, {0xc000040050, 0x3, 0x3})
        /Users/caicooper/Development/go-workspace/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0xc000004780)
        /Users/caicooper/Development/go-workspace/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/caicooper/Development/go-workspace/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main()
        /Users/caicooper/workspace/kubectl-permissions/cmd/kubectl-permissions.go:17 +0xed
```
Perhaps the solution isn't the appropriate method to resolve this, but it made sense to be able to list multiple API groups per resource 🤷 .

```sh
$ k permissions "deployment-controller" -n kube-system                                                                                                    ─╯
ServiceAccount/deployment-controller (kube-system)
└ ClusterRoleBinding/system:controller:deployment-controller
  └ ClusterRole/system:controller:deployment-controller
    ├ apps
    │ ├ deployments verbs=[get list update watch]
    │ ├ deployments/finalizers verbs=[update]
    │ ├ deployments/status verbs=[update]
    │ └ replicasets verbs=[create delete get list patch update watch]
    ├ core.k8s.io
    │ ├ events verbs=[create patch update]
    │ └ pods verbs=[get list update watch]
    ├ events.k8s.io
    │ └ events verbs=[create patch update]
    └ extensions
      ├ deployments verbs=[get list update watch]
      ├ deployments/finalizers verbs=[update]
      ├ deployments/status verbs=[update]
      └ replicasets verbs=[create delete get list patch update watch]
```