### PR TITLE
fix: improve error message when there are zero args

### DIFF
--- a/pkg/cmd/permissions.go
+++ b/pkg/cmd/permissions.go
@@ -92,7 +92,8 @@ func (o *PermissionsOptions) Run() error {
 	}
 
 	if len(o.Args) != 1 {
-		panic(fmt.Sprintf("Error: accepts 1 arg(s), received %d", len(o.Args)))
+		fmt.Println("Usage:", o.Cmd.Use)
+		return fmt.Errorf("error: accepts 1 arg(s), received %d", len(o.Args))
 	}
 
 	var err error


### PR DESCRIPTION
```
❯ ./kubectl-permissions
Usage: kubectl permissions [service-account] [flags]
Error: error: accepts 1 arg(s), received 0
```